### PR TITLE
correct example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python reporter.py config.yml
 poll_interval: 15
 environment: dev
 routers:
-  - host: 29.38.10.2
+  - hostname: 29.38.10.2
     community: pgbcommunity
     routes:
       - 29.28.10.3


### PR DESCRIPTION
I was looking through this today and realized that the example config uses `host` and the app itself is looking for `hostname`. Looks like it needs to be `hostname`.