### PR TITLE
debian version changed to buster in upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:2
 
-RUN sed -i "s#deb http://deb.debian.org/debian stretch main#deb http://deb.debian.org/debian stretch main contrib non-free#g" /etc/apt/sources.list
-RUN sed -i "s#deb http://deb.debian.org/debian stretch-updates main#deb http://http.us.debian.org/debian stretch-updates main contrib non-free#g" /etc/apt/sources.list
-RUN sed -i "s#deb http://security.debian.org/debian stretch/updates main#deb http://security.debian.org/debian stretch/updates main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://deb.debian.org/debian buster main#deb http://deb.debian.org/debian buster main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://deb.debian.org/debian buster-updates main#deb http://http.us.debian.org/debian buster-updates main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://security.debian.org/debian buster/updates main#deb http://security.debian.org/debian buster/updates main contrib non-free#g" /etc/apt/sources.list
 RUN apt update
 RUN apt install -y gcc python-dev libsnmp-dev snmp-mibs-downloader
 RUN mkdir /usr/src/csr_reporter


### PR DESCRIPTION
Stretch changed to "oldstable" recently and it looks like `python:2` changed to buster along with it.