### PR TITLE
Update to latest release, bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3
 
-RUN sed -i "s#deb http://deb.debian.org/debian bullseye main#deb http://deb.debian.org/debian bullseye main contrib non-free#g" /etc/apt/sources.list
-RUN sed -i "s#deb http://deb.debian.org/debian bullseye-updates main#deb http://http.us.debian.org/debian bullseye-updates main contrib non-free#g" /etc/apt/sources.list
-RUN sed -i "s#deb http://security.debian.org/debian bullseye/updates main#deb http://security.debian.org/debian bullseye/updates main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://deb.debian.org/debian bookworm main#deb http://deb.debian.org/debian bookworm main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://deb.debian.org/debian bookworm-updates main#deb http://http.us.debian.org/debian bookworm-updates main contrib non-free#g" /etc/apt/sources.list
+RUN sed -i "s#deb http://security.debian.org/debian bookworm/updates main#deb http://security.debian.org/debian bookworm/updates main contrib non-free#g" /etc/apt/sources.list
 RUN apt update
 RUN apt install -y gcc python-dev libsnmp-dev snmp-mibs-downloader
 RUN mkdir /usr/src/csr_reporter


### PR DESCRIPTION
fwdproxy build was failing with the error:
`msg: 'Error building dsva/network-status-exporter - code: 2, message: The command ''/bin/sh -c sed -i "s#deb http://deb.debian.org/debian bullseye main#deb http://deb.debian.org/debian bullseye main contrib non-free#g" /etc/apt/sources.list'' returned a non-zero code: 2,`

I think this should fix it. I see previous commits to this file where a version change was done.

Slack thread: https://dsva.slack.com/archives/C37M86Y8G/p1686773154444749

### Testing done
none.